### PR TITLE
Added a basic zkp crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
     "vm",
     "compiler",
     "mpc",
-    "types"
+    "types",
+    "zkp"
 ]

--- a/zkp/Cargo.toml
+++ b/zkp/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "zkp"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]

--- a/zkp/src/lib.rs
+++ b/zkp/src/lib.rs
@@ -1,0 +1,8 @@
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn it_works() {
+        let result = 2 + 2;
+        assert_eq!(result, 4);
+    }
+}


### PR DESCRIPTION
As outlined in #14, we should have some basic ZKP utilities that can be used in the StoffelLang. At a later time, we can discuss changes that might allow a more advanced developer to write their own ZKP gadgets to use within StoffelLang. But for now, a basic set of ZKPs should do. This PR is to just change the current repo structure to add this crate. Future PRs will actually implement the basic ZKPs.