### PR TITLE
Inclusion of updates in arkworks-rs/algebra

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,6 @@ members = [
 ]
 
 [patch.crates-io]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
-ark-serialize = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
+ark-ec = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,8 @@ members = [
     "blockchain",
     "player"
 ]
+
+[patch.crates-io]
+ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-ec = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-serialize = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }

--- a/mpc/Cargo.toml
+++ b/mpc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 types = {path = "../types"}
 rand = "0.8"
-ark-ff = "0.4.2"
-ark-poly = "0.4.2"
-ark-bls12-381 = "0.4.0"
+ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
 num-bigint = "0.4"

--- a/mpc/Cargo.toml
+++ b/mpc/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 [dependencies]
 types = {path = "../types"}
 rand = "0.8"
-ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
-ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
+ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
 num-bigint = "0.4"

--- a/player/Cargo.toml
+++ b/player/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 mpc = {path = "../mpc"}
 vm = {path = "../vm"}
 types = {path = "../types"}
-tokio = {version = "0.2", features = ["full"] }
+tokio = {version = "1", features = ["full"] }

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ark-ff = "0.4.2"
-ark-poly = "0.4.2"
-ark-bls12-381 = "0.4.0"
+ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
 thiserror = "1"
 num-bigint = "0.4"

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
-ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
+ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
 thiserror = "1"
 num-bigint = "0.4"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -10,8 +10,8 @@ types = {path = "../types"}
 mpc = {path = "../mpc"}
 futures = { version = "0.3" }
 tokio = {version = "1", features = ["full"] }
-ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
-ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
-ark-ec = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
-ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
+ark-ec = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
+ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra.git", rev = "d9527c8" }
 num-bigint = "0.4.4"

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2021"
 types = {path = "../types"}
 mpc = {path = "../mpc"}
 futures = { version = "0.3" }
-tokio = {version = "0.2", features = ["full"] }
-ark-ff = "0.4.2"
-ark-poly = "0.4.2"
-ark-ec = "0.4"
-ark-bls12-381 = "0.4.0"
+tokio = {version = "1", features = ["full"] }
+ark-ff = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-poly = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-ec = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
+ark-bls12-381 = { git = "https://github.com/arkworks-rs/algebra.git", rev = "b7b988f" }
 num-bigint = "0.4.4"

--- a/vm/src/error.rs
+++ b/vm/src/error.rs
@@ -11,6 +11,9 @@ pub enum VmError {
     /// Error for invalid instruction. It contains the opcode that is being
     /// accessed wrongly.
     InvalidInstruction(usize),
+
+    /// Error for invalid conversion.
+    ConversionError,
 }
 
 impl std::error::Error for VmError {}

--- a/vm/src/instructions/arithmetic.rs
+++ b/vm/src/instructions/arithmetic.rs
@@ -1,4 +1,4 @@
-use ark_ff::{BigInteger, Field, LegendreSymbol, PrimeField};
+use ark_ff::{BigInteger, Field, LegendreSymbol, PrimeField, BigInt};
 
 use std::sync::{Arc, Mutex};
 
@@ -675,7 +675,10 @@ pub fn andc<T: MPCProtocol>(
 
     let and = value1_bigint & value2_bigint;
 
-    let and_domain = from_bigint_to_domain::<T>(and);
+    let and_domain = match T::Domain::from_bigint(and) {
+        Some(value) => value,
+        None => return Err(VmError::ConversionError),
+    };
     processor
         .clear_register_mut()
         .write(reg_addr_result, and_domain)?;
@@ -692,12 +695,15 @@ pub fn xorc<T: MPCProtocol>(
     let value1 = processor.clear_register().read(reg_addr1)?;
     let value2 = processor.clear_register().read(reg_addr2)?;
 
-    let value1_bigint = from_domain_to_bigint::<T>(value1);
-    let value2_bigint = from_domain_to_bigint::<T>(value2);
+    let value1_bigint = value1.into_bigint();
+    let value2_bigint = value2.into_bigint();
 
     let xor = value1_bigint ^ value2_bigint;
 
-    let xor_domain = from_bigint_to_domain::<T>(xor);
+    let xor_domain = match T::Domain::from_bigint(xor) {
+        Some(value) => value,
+        None => return Err(VmError::ConversionError),
+    };
     processor
         .clear_register_mut()
         .write(reg_addr_result, xor_domain)?;
@@ -714,12 +720,15 @@ pub fn orc<T: MPCProtocol>(
     let value1 = processor.clear_register().read(reg_addr1)?;
     let value2 = processor.clear_register().read(reg_addr2)?;
 
-    let value1_bigint = from_domain_to_bigint::<T>(value1);
-    let value2_bigint = from_domain_to_bigint::<T>(value2);
+    let value1_bigint = value1.into_bigint();
+    let value2_bigint = value2.into_bigint();
 
     let or = value1_bigint | value2_bigint;
 
-    let or_domain = from_bigint_to_domain::<T>(or);
+    let or_domain = match T::Domain::from_bigint(or) {
+        Some(value) => value,
+        None => return Err(VmError::ConversionError),
+    };
     processor
         .clear_register_mut()
         .write(reg_addr_result, or_domain)?;
@@ -734,13 +743,16 @@ pub fn andci<T: MPCProtocol>(
     reg_addr_result: RegisterAddr,
 ) -> Result<(), VmError> {
     let stored_value = processor.clear_register().read(reg_addr)?;
-    let stored_value_bigint = from_domain_to_bigint::<T>(stored_value);
+    let stored_value_bigint = stored_value.into_bigint();
 
-    let imm_value_bigint = from_domain_to_bigint::<T>(immediate_val);
+    let imm_value_bigint = immediate_val.into_bigint();
 
     let and_bigint = stored_value_bigint & imm_value_bigint;
 
-    let and_domain = from_bigint_to_domain::<T>(and_bigint);
+    let and_domain = match T::Domain::from_bigint(and_bigint) {
+        Some(value) => value, 
+        None => return Err(VmError::ConversionError),
+    };
     processor
         .clear_register_mut()
         .write(reg_addr_result, and_domain)?;
@@ -755,13 +767,16 @@ pub fn xorci<T: MPCProtocol>(
     reg_addr_result: RegisterAddr,
 ) -> Result<(), VmError> {
     let stored_value = processor.clear_register().read(reg_addr)?;
-    let stored_value_bigint = from_domain_to_bigint::<T>(stored_value);
+    let stored_value_bigint = stored_value.into_bigint();
 
-    let imm_value_bigint = from_domain_to_bigint::<T>(immediate_val);
+    let imm_value_bigint = immediate_val.into_bigint();
 
     let xor_bigint = stored_value_bigint ^ imm_value_bigint;
 
-    let xor_domain = from_bigint_to_domain::<T>(xor_bigint);
+    let xor_domain = match T::Domain::from_bigint(xor_bigint) {
+        Some(value) => value,
+        None => return Err(VmError::ConversionError),
+    };
     processor
         .clear_register_mut()
         .write(reg_addr_result, xor_domain)?;
@@ -776,13 +791,16 @@ pub fn orci<T: MPCProtocol>(
     reg_addr_result: RegisterAddr,
 ) -> Result<(), VmError> {
     let stored_value = processor.clear_register().read(reg_addr)?;
-    let stored_value_bigint = from_domain_to_bigint::<T>(stored_value);
+    let stored_value_bigint = stored_value.into_bigint();
 
-    let imm_value_bigint = from_domain_to_bigint::<T>(immediate_val);
+    let imm_value_bigint = immediate_val.into_bigint();
 
     let or_bigint = stored_value_bigint | imm_value_bigint;
 
-    let or_domain = from_bigint_to_domain::<T>(or_bigint);
+    let or_domain = match T::Domain::from_bigint(or_bigint) {
+        Some(value) => value, 
+        None => return Err(VmError::ConversionError),
+    };
     processor
         .clear_register_mut()
         .write(reg_addr_result, or_domain)?;
@@ -1078,7 +1096,10 @@ mod test {
         let reg_addr: RegisterAddr = 4;
         let value = Fr::new(12_u64.into());
 
-        ldi(&mut processor, reg_addr, value);
+        match ldi(&mut processor, reg_addr, value) {
+            Err(err) => panic!("{}", err),
+            Ok(()) => {}
+        };
 
         assert_eq!(processor.clear_register().read(reg_addr).unwrap(), value);
     }
@@ -1090,7 +1111,10 @@ mod test {
         let value = Fr::new(12_u64.into());
         let share = Share::new(value);
 
-        ldsi(&mut processor, reg_addr, share);
+        match ldsi(&mut processor, reg_addr, share) {
+            Err(err) => panic!("{}", err),
+            Ok(()) => {}
+        };
 
         assert_eq!(processor.secret_register().read(reg_addr).unwrap(), share);
     }

--- a/vm/src/instructions/arithmetic.rs
+++ b/vm/src/instructions/arithmetic.rs
@@ -6,7 +6,7 @@ use crate::{error::VmError, processor::arithmetic::ArithmeticCore, state::Memory
 use mpc::protocols::MPCProtocol;
 use mpc::share::Share;
 use types::vm::{MemoryAddr, RegisterAddr};
-
+use ark_ff::AdditiveGroup;
 use num_bigint::BigUint;
 
 fn from_domain_to_bigint<T: MPCProtocol>(value: T::Domain) -> BigUint {

--- a/vm/src/instructions/arithmetic.rs
+++ b/vm/src/instructions/arithmetic.rs
@@ -670,8 +670,8 @@ pub fn andc<T: MPCProtocol>(
     let value1 = processor.clear_register().read(reg_addr1)?;
     let value2 = processor.clear_register().read(reg_addr2)?;
 
-    let value1_bigint = from_domain_to_bigint::<T>(value1);
-    let value2_bigint = from_domain_to_bigint::<T>(value2);
+    let value1_bigint = value1.into_bigint();
+    let value2_bigint = value2.into_bigint();
 
     let and = value1_bigint & value2_bigint;
 


### PR DESCRIPTION
In this PR, I included the updates of [arkworks-rs/algebra](https://github.com/arkworks-rs/algebra) that we need for the arithmetic instructions. The PRs that were updated in the mentioned repository are the following:
- https://github.com/arkworks-rs/algebra/pull/713
- https://github.com/arkworks-rs/algebra/pull/716
With those PRs, the arithmetic instructions that involve bitwise operations AND, OR, and XOR only rely on arkworks-rs.